### PR TITLE
Add DRF list token lookup

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,3 +18,13 @@ python manage.py runserver
 The default database uses SQLite and stores data in `db.sqlite3`.
 The backend exposes a REST API powered by Django REST Framework and
 supports WebSocket connections through Django Channels.
+
+## REST API
+
+The API is available under the `/api/` path. Todo lists can be created with a
+POST request to `/api/lists/`. Each list is identified by a unique `token` that
+can be used to retrieve the list or its associated items. All CRUD operations
+for todo items are exposed through `/api/items/`.
+
+To fetch all items for a specific list, send a GET request to
+`/api/lists/{token}/items/`.

--- a/backend/grouptodo/todos/tests.py
+++ b/backend/grouptodo/todos/tests.py
@@ -10,3 +10,27 @@ class TodoModelTests(TestCase):
         self.assertEqual(item.text, "Task")
         self.assertFalse(item.is_completed)
         self.assertIn(item, todo_list.items.all())
+
+
+class TodoAPITests(TestCase):
+    """API tests for todo list and items."""
+
+    def test_create_list_and_retrieve_items(self) -> None:
+        # Create list via API
+        response = self.client.post("/api/lists/")
+        self.assertEqual(response.status_code, 201)
+        token = response.json()["token"]
+        list_id = response.json()["id"]
+
+        # Create an item in that list
+        item_response = self.client.post(
+            "/api/items/", {"list": list_id, "text": "Task"}
+        )
+        self.assertEqual(item_response.status_code, 201)
+
+        # Retrieve items via list token
+        items_response = self.client.get(f"/api/lists/{token}/items/")
+        self.assertEqual(items_response.status_code, 200)
+        data = items_response.json()
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["text"], "Task")

--- a/backend/grouptodo/todos/views.py
+++ b/backend/grouptodo/todos/views.py
@@ -1,4 +1,6 @@
 from rest_framework import viewsets
+from rest_framework.decorators import action
+from rest_framework.response import Response
 from .models import TodoList, TodoItem
 from .serializers import TodoListSerializer, TodoItemSerializer
 
@@ -6,6 +8,14 @@ from .serializers import TodoListSerializer, TodoItemSerializer
 class TodoListViewSet(viewsets.ModelViewSet):
     queryset = TodoList.objects.all()
     serializer_class = TodoListSerializer
+    lookup_field = "token"
+
+    @action(detail=True, methods=["get"])
+    def items(self, request, token=None):
+        """Return all todo items for this list."""
+        todo_list = self.get_object()
+        serializer = TodoItemSerializer(todo_list.items.all(), many=True)
+        return Response(serializer.data)
 
 
 class TodoItemViewSet(viewsets.ModelViewSet):


### PR DESCRIPTION
## Summary
- allow looking up todo lists by token instead of primary key
- expose `/api/lists/<token>/items/` endpoint for all items in a list
- document REST API
- cover new endpoint in tests

## Testing
- `poetry run python manage.py test` *(fails: ModuleNotFoundError: No module named 'django')*

------
https://chatgpt.com/codex/tasks/task_e_68893bbe647c83258c3fe62d76305139