### PR TITLE
Ensure TodoList token generated server-side

### DIFF
--- a/backend/grouptodo/todos/tests.py
+++ b/backend/grouptodo/todos/tests.py
@@ -34,3 +34,9 @@ class TodoAPITests(TestCase):
         data = items_response.json()
         self.assertEqual(len(data), 1)
         self.assertEqual(data[0]["text"], "Task")
+
+    def test_server_generates_token(self) -> None:
+        """Ensure the API ignores user-provided tokens."""
+        response = self.client.post("/api/lists/", {"token": "malicious"})
+        self.assertEqual(response.status_code, 201)
+        self.assertNotEqual(response.json()["token"], "malicious")

--- a/backend/grouptodo/todos/views.py
+++ b/backend/grouptodo/todos/views.py
@@ -1,4 +1,4 @@
-from rest_framework import viewsets
+from rest_framework import status, viewsets
 from rest_framework.decorators import action
 from rest_framework.response import Response
 from .models import TodoList, TodoItem
@@ -9,6 +9,13 @@ class TodoListViewSet(viewsets.ModelViewSet):
     queryset = TodoList.objects.all()
     serializer_class = TodoListSerializer
     lookup_field = "token"
+
+    def create(self, request, *args, **kwargs):
+        """Create a new todo list with a server-generated token."""
+        todo_list = TodoList.objects.create()
+        serializer = self.get_serializer(todo_list)
+        headers = self.get_success_headers(serializer.data)
+        return Response(serializer.data, status=status.HTTP_201_CREATED, headers=headers)
 
     @action(detail=True, methods=["get"])
     def items(self, request, token=None):


### PR DESCRIPTION
## Summary
- generate unique token in `TodoListViewSet.create`
- add regression test verifying server-generated token

## Testing
- `poetry install` *(fails: no internet)*
- `poetry run python manage.py test` *(fails: Django not installed)*

------
https://chatgpt.com/codex/tasks/task_e_688a5f25b5c88325bb2677eead547a06