### PR TITLE
Add Docker Compose setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,3 +28,16 @@ for todo items are exposed through `/api/items/`.
 
 To fetch all items for a specific list, send a GET request to
 `/api/lists/{token}/items/`.
+
+## Docker Compose
+
+A `docker-compose.yml` is provided to run both the backend and frontend
+services together. Build and start the stack with:
+
+```bash
+docker compose up --build
+```
+
+The backend will be available on `http://localhost:8000` and the frontend
+Vite dev server on `http://localhost:5173`.
+

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,18 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Install Poetry
+RUN pip install --no-cache-dir poetry
+
+# Copy dependency files
+COPY pyproject.toml poetry.lock ./
+
+# Install dependencies
+RUN poetry config virtualenvs.create false \
+    && poetry install --no-interaction --no-ansi
+
+# Copy source code
+COPY . .
+
+CMD ["python", "manage.py", "runserver", "0.0.0.0:8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.9'
+services:
+  backend:
+    build: ./backend
+    volumes:
+      - ./backend:/app
+    ports:
+      - "8000:8000"
+  frontend:
+    build: ./frontend
+    volumes:
+      - ./frontend:/app
+    ports:
+      - "5173:5173"
+    depends_on:
+      - backend

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,12 @@
+FROM node:20-alpine
+
+WORKDIR /app
+
+# Install dependencies
+COPY package.json package-lock.json ./
+RUN npm ci
+
+# Copy source code
+COPY . .
+
+CMD ["npm", "run", "dev", "--", "--host", "0.0.0.0", "--port", "5173"]


### PR DESCRIPTION
## Summary
- add Dockerfile for backend to install Python dependencies with Poetry
- add Dockerfile for frontend for the Vite dev server
- introduce a docker-compose.yml that launches both services
- document how to run the stack in README

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_688a6578ba888325abeb638ef29d0cc6