### PR TITLE
Add nginx proxy for frontend and backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,15 @@ supports WebSocket connections through Django Channels.
 
 ## Docker Compose
 
-You can also run the project using Docker Compose. This will start both the
-backend and frontend services:
+You can also run the project using Docker Compose. This will start the backend
+and frontend services behind an Nginx proxy:
 
 ```bash
 docker-compose up --build
 ```
 
-The Django API will be available at `http://localhost:8000` and the Parcel dev
-server at `http://localhost:3000`.
+Visit `http://localhost:3000` to access the Parcel dev server. Requests under
+`/api` are automatically routed to the Django backend.
 
 ## REST API
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,8 +6,6 @@ services:
       context: ./backend
     volumes:
       - ./backend:/app
-    ports:
-      - "8000:8000"
     command: sh -c "python manage.py migrate && python manage.py runserver 0.0.0.0:8000"
 
   frontend:
@@ -16,6 +14,14 @@ services:
     volumes:
       - ./frontend:/app
       - /app/node_modules
-    ports:
-      - "3000:1234"
     command: npm run dev
+
+  nginx:
+    image: nginx:alpine
+    volumes:
+      - ./nginx/nginx.conf:/etc/nginx/nginx.conf:ro
+    ports:
+      - "3000:80"
+    depends_on:
+      - frontend
+      - backend

--- a/nginx/nginx.conf
+++ b/nginx/nginx.conf
@@ -1,0 +1,24 @@
+events {}
+http {
+    server {
+        listen 80;
+
+        location /api/ {
+            proxy_pass http://backend:8000;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+
+        location / {
+            proxy_pass http://frontend:1234;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+            proxy_set_header Host $host;
+            proxy_set_header X-Real-IP $remote_addr;
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Add nginx reverse proxy container to route `/` to the frontend dev server and `/api` to the Django backend
- Document nginx setup in README

## Testing
- `docker compose config` *(fails: command not found)*
- `apt-get update` *(fails: 403 Forbidden)*
- `cd backend && poetry run python manage.py test`
- `cd frontend && npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_688e38ec5b748325a3ce738c604a2b2c