### PR TITLE
Add token list creation button and placeholder list

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,34 @@
 import useStore from './store';
 
 function App() {
-  const message = useStore((state) => state.message);
-  return <h1>{message}</h1>;
+  const token = useStore((state) => state.token);
+  const setToken = useStore((state) => state.setToken);
+
+  const handleClick = async () => {
+    const response = await fetch('/api/lists/', { method: 'POST' });
+    const data = await response.json();
+    setToken(data.token);
+    window.history.pushState(null, '', `/${data.token}`);
+  };
+
+  return (
+    <div
+      style={{
+        display: 'flex',
+        flexDirection: 'column',
+        alignItems: 'center',
+        justifyContent: 'center',
+        height: '100vh',
+      }}
+    >
+      {!token && (
+        <button onClick={handleClick}>Get Busy!</button>
+      )}
+      <ul>
+        <li>Under Construction</li>
+      </ul>
+    </div>
+  );
 }
 
 export default App;

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,8 +1,16 @@
+import { useEffect } from 'react';
 import useStore from './store';
 
 function App() {
   const token = useStore((state) => state.token);
   const setToken = useStore((state) => state.setToken);
+
+  useEffect(() => {
+    const urlToken = window.location.pathname.slice(1);
+    if (urlToken) {
+      setToken(urlToken);
+    }
+  }, [setToken]);
 
   const handleClick = async () => {
     const response = await fetch('/api/lists/', { method: 'POST' });
@@ -24,9 +32,11 @@ function App() {
       {!token && (
         <button onClick={handleClick}>Get Busy!</button>
       )}
-      <ul>
-        <li>Under Construction</li>
-      </ul>
+      {token && (
+        <ul>
+          <li>Under Construction</li>
+        </ul>
+      )}
     </div>
   );
 }

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -2,8 +2,12 @@ import { create } from 'zustand';
 
 type State = {
   message: string;
+  token: string | null;
+  setToken: (token: string) => void;
 };
 
-export default create<State>(() => ({
-  message: 'Hello React!'
+export default create<State>((set) => ({
+  message: 'Hello React!',
+  token: null,
+  setToken: (token) => set({ token }),
 }));


### PR DESCRIPTION
## Summary
- central "Get Busy!" button creates a todo list via API and updates the URL with the returned token
- introduce token state management with Zustand
- show placeholder todo list item 'Under Construction'

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run build`
- `cd backend && poetry run python manage.py test`


------
https://chatgpt.com/codex/tasks/task_e_688e3d22e53883259897d48d11cd1432