### PR TITLE
feat: add placeholder item for new todos

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -5,14 +5,19 @@ import ListItem from '@mui/material/ListItem';
 import ListItemText from '@mui/material/ListItemText';
 import Checkbox from '@mui/material/Checkbox';
 import Box from '@mui/material/Box';
+import TextField from '@mui/material/TextField';
+import IconButton from '@mui/material/IconButton';
 import useStore from './store';
 
 function App() {
   const token = useStore((state) => state.token);
+  const listId = useStore((state) => state.listId);
   const setToken = useStore((state) => state.setToken);
+  const setListId = useStore((state) => state.setListId);
   const [items, setItems] = useState<
     { id: number; text: string; is_completed: boolean }[]
   >([]);
+  const [newItemText, setNewItemText] = useState('');
 
   useEffect(() => {
     const urlToken = window.location.pathname.slice(1);
@@ -21,19 +26,40 @@ function App() {
     }
   }, [setToken]);
 
-  useEffect(() => {
+  const fetchItems = () => {
     if (token) {
       fetch(`/api/lists/${token}/items/`)
         .then((res) => res.json())
         .then((data) => setItems(data));
     }
-  }, [token]);
+  };
+
+  useEffect(() => {
+    if (token) {
+      fetch(`/api/lists/${token}/`)
+        .then((res) => res.json())
+        .then((data) => setListId(data.id));
+      fetchItems();
+    }
+  }, [token, setListId]);
 
   const handleClick = async () => {
     const response = await fetch('/api/lists/', { method: 'POST' });
     const data = await response.json();
     setToken(data.token);
+    setListId(data.id);
     window.history.pushState(null, '', `/${data.token}`);
+  };
+
+  const handleAdd = async () => {
+    if (!newItemText.trim() || !listId) return;
+    await fetch('/api/items/', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ list: listId, text: newItemText }),
+    });
+    setNewItemText('');
+    fetchItems();
   };
 
   return (
@@ -59,6 +85,15 @@ function App() {
               <ListItemText primary={item.text} />
             </ListItem>
           ))}
+          <ListItem disablePadding>
+            <IconButton onClick={handleAdd}>+</IconButton>
+            <TextField
+              variant="standard"
+              placeholder="Add an item"
+              value={newItemText}
+              onChange={(e) => setNewItemText(e.target.value)}
+            />
+          </ListItem>
         </List>
       )}
     </Box>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -62,6 +62,15 @@ function App() {
     fetchItems();
   };
 
+  const handleToggle = async (id: number, isCompleted: boolean) => {
+    await fetch(`/api/items/${id}/`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ is_completed: !isCompleted }),
+    });
+    fetchItems();
+  };
+
   return (
     <Box
       sx={{
@@ -81,7 +90,10 @@ function App() {
         <List>
           {items.map((item) => (
             <ListItem key={item.id} disablePadding>
-              <Checkbox checked={item.is_completed} />
+              <Checkbox
+                checked={item.is_completed}
+                onChange={() => handleToggle(item.id, item.is_completed)}
+              />
               <ListItemText primary={item.text} />
             </ListItem>
           ))}

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -71,6 +71,11 @@ function App() {
     fetchItems();
   };
 
+  const handleDelete = async (id: number) => {
+    await fetch(`/api/items/${id}/`, { method: 'DELETE' });
+    fetchItems();
+  };
+
   return (
     <Box
       sx={{
@@ -95,6 +100,12 @@ function App() {
                 onChange={() => handleToggle(item.id, item.is_completed)}
               />
               <ListItemText primary={item.text} />
+              <IconButton
+                onClick={() => handleDelete(item.id)}
+                sx={{ color: 'red', marginLeft: 'auto' }}
+              >
+                -
+              </IconButton>
             </ListItem>
           ))}
           <ListItem disablePadding>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -92,6 +92,11 @@ function App() {
               placeholder="Add an item"
               value={newItemText}
               onChange={(e) => setNewItemText(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter') {
+                  handleAdd();
+                }
+              }}
             />
           </ListItem>
         </List>

--- a/frontend/src/store.ts
+++ b/frontend/src/store.ts
@@ -3,11 +3,15 @@ import { create } from 'zustand';
 type State = {
   message: string;
   token: string | null;
+  listId: number | null;
   setToken: (token: string) => void;
+  setListId: (id: number) => void;
 };
 
 export default create<State>((set) => ({
   message: 'Hello React!',
   token: null,
+  listId: null,
   setToken: (token) => set({ token }),
+  setListId: (id) => set({ listId: id }),
 }));


### PR DESCRIPTION
## Summary
- add placeholder row with plus button to add todos
- store list id in state to associate new items

## Testing
- `npm test` (fails: Missing script)
- `npm run build`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_688e754a37548325a7c66413645d6309