### PR TITLE
feat: show item descriptions with edit and delete

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -10,6 +10,7 @@
       "dependencies": {
         "@emotion/react": "^11.11.0",
         "@emotion/styled": "^11.11.0",
+        "@mui/icons-material": "^5.15.0",
         "@mui/material": "^5.15.0",
         "react": "^18.0.0",
         "react-dom": "^18.0.0",
@@ -550,6 +551,32 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/mui-org"
+      }
+    },
+    "node_modules/@mui/icons-material": {
+      "version": "5.18.0",
+      "resolved": "https://registry.npmjs.org/@mui/icons-material/-/icons-material-5.18.0.tgz",
+      "integrity": "sha512-1s0vEZj5XFXDMmz3Arl/R7IncFqJ+WQ95LDp1roHWGDE2oCO3IS4/hmiOv1/8SD9r6B7tv9GLiqVZYHo+6PkTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.23.9"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui-org"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.0.0",
+        "@types/react": "^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react": "^17.0.0 || ^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        }
       }
     },
     "node_modules/@mui/material": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,6 +11,7 @@
     "react-dom": "^18.0.0",
     "zustand": "^4.0.0",
     "@mui/material": "^5.15.0",
+    "@mui/icons-material": "^5.15.0",
     "@emotion/react": "^11.11.0",
     "@emotion/styled": "^11.11.0"
   },


### PR DESCRIPTION
## Summary
- expand items via a down arrow to reveal their descriptions
- edit descriptions with a pencil/floppy-disk toggle and remove items with a trash icon
- add Material Icons package

## Testing
- `npm test` *(fails: Missing script)*
- `poetry run python manage.py test` *(fails: asyncio.exceptions.CancelledError)*

------
https://chatgpt.com/codex/tasks/task_e_689101e3e3908325bfff58306de94ce8