### PR TITLE
Enhance landing page with modern responsive design

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -122,6 +122,74 @@ function App() {
     fetchItems();
   };
 
+  const renderItem = (
+    item: {
+      id: number;
+      text: string;
+      description: string | null;
+      is_completed: boolean;
+    }
+  ) => (
+    <ListItem
+      key={item.id}
+      disablePadding
+      sx={{ flexDirection: 'column', alignItems: 'stretch' }}
+    >
+      <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+        <Checkbox
+          checked={item.is_completed}
+          onChange={() => handleToggle(item.id, item.is_completed)}
+        />
+        <ListItemText primary={item.text} />
+        <IconButton
+          onClick={() => toggleExpand(item.id)}
+          sx={{ marginLeft: 'auto' }}
+        >
+          {expanded[item.id] ? <ExpandLessIcon /> : <ExpandMoreIcon />}
+        </IconButton>
+      </Box>
+      <Collapse in={!!expanded[item.id]} timeout="auto" unmountOnExit>
+        <Box sx={{ p: 2 }}>
+          {editing[item.id] ? (
+            <TextField
+              fullWidth
+              multiline
+              variant="standard"
+              value={descriptions[item.id] || ''}
+              onChange={(e) =>
+                setDescriptions({
+                  ...descriptions,
+                  [item.id]: e.target.value,
+                })
+              }
+            />
+          ) : (
+            <Typography>{item.description}</Typography>
+          )}
+          <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+            {editing[item.id] ? (
+              <IconButton onClick={() => saveDescription(item.id)}>
+                <SaveIcon />
+              </IconButton>
+            ) : (
+              <IconButton
+                onClick={() => startEdit(item.id, item.description)}
+              >
+                <EditIcon />
+              </IconButton>
+            )}
+            <IconButton
+              onClick={() => handleDelete(item.id)}
+              sx={{ color: 'red' }}
+            >
+              <DeleteIcon />
+            </IconButton>
+          </Box>
+        </Box>
+      </Collapse>
+    </ListItem>
+  );
+
   return (
     <Box
       sx={{
@@ -165,68 +233,8 @@ function App() {
             elevation={3}
             sx={{ p: { xs: 2, sm: 3 }, bgcolor: 'rgba(255,255,255,0.9)' }}
           >
-            <List sx={{ width: '100%' }}>
-              {items.map((item) => (
-                <ListItem
-                  key={item.id}
-                  disablePadding
-                  sx={{ flexDirection: 'column', alignItems: 'stretch' }}
-                >
-                  <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
-                    <Checkbox
-                      checked={item.is_completed}
-                      onChange={() => handleToggle(item.id, item.is_completed)}
-                    />
-                    <ListItemText primary={item.text} />
-                    <IconButton
-                      onClick={() => toggleExpand(item.id)}
-                      sx={{ marginLeft: 'auto' }}
-                    >
-                      {expanded[item.id] ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                    </IconButton>
-                  </Box>
-                  <Collapse in={!!expanded[item.id]} timeout="auto" unmountOnExit>
-                    <Box sx={{ p: 2 }}>
-                      {editing[item.id] ? (
-                        <TextField
-                          fullWidth
-                          multiline
-                          variant="standard"
-                          value={descriptions[item.id] || ''}
-                          onChange={(e) =>
-                            setDescriptions({
-                              ...descriptions,
-                              [item.id]: e.target.value,
-                            })
-                          }
-                        />
-                      ) : (
-                        <Typography>{item.description}</Typography>
-                      )}
-                      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                        {editing[item.id] ? (
-                          <IconButton onClick={() => saveDescription(item.id)}>
-                            <SaveIcon />
-                          </IconButton>
-                        ) : (
-                          <IconButton
-                            onClick={() => startEdit(item.id, item.description)}
-                          >
-                            <EditIcon />
-                          </IconButton>
-                        )}
-                        <IconButton
-                          onClick={() => handleDelete(item.id)}
-                          sx={{ color: 'red' }}
-                        >
-                          <DeleteIcon />
-                        </IconButton>
-                      </Box>
-                    </Box>
-                  </Collapse>
-                </ListItem>
-              ))}
-              <ListItem disablePadding>
+            <Box sx={{ width: '100%' }}>
+              <Box sx={{ display: 'flex', alignItems: 'center', mb: 2 }}>
                 <IconButton onClick={handleAdd}>+</IconButton>
                 <TextField
                   variant="standard"
@@ -241,8 +249,18 @@ function App() {
                   fullWidth
                   sx={{ ml: 1 }}
                 />
-              </ListItem>
-            </List>
+              </Box>
+              <List>
+                {items
+                  .filter((item) => !item.is_completed)
+                  .map((item) => renderItem(item))}
+              </List>
+              <List sx={{ mt: 2 }}>
+                {items
+                  .filter((item) => item.is_completed)
+                  .map((item) => renderItem(item))}
+              </List>
+            </Box>
           </Paper>
         )}
       </Container>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,8 @@ import TextField from '@mui/material/TextField';
 import IconButton from '@mui/material/IconButton';
 import Collapse from '@mui/material/Collapse';
 import Typography from '@mui/material/Typography';
+import Container from '@mui/material/Container';
+import Paper from '@mui/material/Paper';
 import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 import ExpandLessIcon from '@mui/icons-material/ExpandLess';
 import DeleteIcon from '@mui/icons-material/Delete';
@@ -123,96 +125,127 @@ function App() {
   return (
     <Box
       sx={{
+        minHeight: '100vh',
         display: 'flex',
-        flexDirection: 'column',
         alignItems: 'center',
         justifyContent: 'center',
-        height: '100vh',
+        background: 'linear-gradient(135deg, #667eea 0%, #764ba2 100%)',
+        p: 2,
       }}
     >
-      {!token && (
-        <Button variant="contained" onClick={handleClick}>
-          Get Busy!
-        </Button>
-      )}
-      {token && (
-        <List>
-          {items.map((item) => (
-            <ListItem
-              key={item.id}
-              disablePadding
-              sx={{ flexDirection: 'column', alignItems: 'stretch' }}
+      <Container maxWidth="sm" sx={{ textAlign: 'center' }}>
+        <Typography
+          variant="h3"
+          component="h1"
+          sx={{ mb: 4, fontWeight: 'bold', color: 'common.white' }}
+        >
+          ToDone!
+        </Typography>
+        {!token && (
+          <>
+            <Button
+              variant="contained"
+              color="secondary"
+              onClick={handleClick}
             >
-              <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
-                <Checkbox
-                  checked={item.is_completed}
-                  onChange={() => handleToggle(item.id, item.is_completed)}
-                />
-                <ListItemText primary={item.text} />
-                <IconButton
-                  onClick={() => toggleExpand(item.id)}
-                  sx={{ marginLeft: 'auto' }}
+              Get Busy!
+            </Button>
+            <Typography
+              variant="body1"
+              sx={{ mt: 4, color: 'common.white' }}
+            >
+              Click "Get Busy!" to create a new shared list. Add tasks with the
+              + button, expand items to add details, and check them off when
+              you're done.
+            </Typography>
+          </>
+        )}
+        {token && (
+          <Paper
+            elevation={3}
+            sx={{ p: { xs: 2, sm: 3 }, bgcolor: 'rgba(255,255,255,0.9)' }}
+          >
+            <List sx={{ width: '100%' }}>
+              {items.map((item) => (
+                <ListItem
+                  key={item.id}
+                  disablePadding
+                  sx={{ flexDirection: 'column', alignItems: 'stretch' }}
                 >
-                  {expanded[item.id] ? <ExpandLessIcon /> : <ExpandMoreIcon />}
-                </IconButton>
-              </Box>
-              <Collapse in={!!expanded[item.id]} timeout="auto" unmountOnExit>
-                <Box sx={{ p: 2 }}>
-                  {editing[item.id] ? (
-                    <TextField
-                      fullWidth
-                      multiline
-                      variant="standard"
-                      value={descriptions[item.id] || ''}
-                      onChange={(e) =>
-                        setDescriptions({
-                          ...descriptions,
-                          [item.id]: e.target.value,
-                        })
-                      }
+                  <Box sx={{ display: 'flex', alignItems: 'center', width: '100%' }}>
+                    <Checkbox
+                      checked={item.is_completed}
+                      onChange={() => handleToggle(item.id, item.is_completed)}
                     />
-                  ) : (
-                    <Typography>{item.description}</Typography>
-                  )}
-                  <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
-                    {editing[item.id] ? (
-                      <IconButton onClick={() => saveDescription(item.id)}>
-                        <SaveIcon />
-                      </IconButton>
-                    ) : (
-                      <IconButton
-                        onClick={() => startEdit(item.id, item.description)}
-                      >
-                        <EditIcon />
-                      </IconButton>
-                    )}
+                    <ListItemText primary={item.text} />
                     <IconButton
-                      onClick={() => handleDelete(item.id)}
-                      sx={{ color: 'red' }}
+                      onClick={() => toggleExpand(item.id)}
+                      sx={{ marginLeft: 'auto' }}
                     >
-                      <DeleteIcon />
+                      {expanded[item.id] ? <ExpandLessIcon /> : <ExpandMoreIcon />}
                     </IconButton>
                   </Box>
-                </Box>
-              </Collapse>
-            </ListItem>
-          ))}
-          <ListItem disablePadding>
-            <IconButton onClick={handleAdd}>+</IconButton>
-            <TextField
-              variant="standard"
-              placeholder="Add an item"
-              value={newItemText}
-              onChange={(e) => setNewItemText(e.target.value)}
-              onKeyDown={(e) => {
-                if (e.key === 'Enter') {
-                  handleAdd();
-                }
-              }}
-            />
-          </ListItem>
-        </List>
-      )}
+                  <Collapse in={!!expanded[item.id]} timeout="auto" unmountOnExit>
+                    <Box sx={{ p: 2 }}>
+                      {editing[item.id] ? (
+                        <TextField
+                          fullWidth
+                          multiline
+                          variant="standard"
+                          value={descriptions[item.id] || ''}
+                          onChange={(e) =>
+                            setDescriptions({
+                              ...descriptions,
+                              [item.id]: e.target.value,
+                            })
+                          }
+                        />
+                      ) : (
+                        <Typography>{item.description}</Typography>
+                      )}
+                      <Box sx={{ display: 'flex', justifyContent: 'flex-end' }}>
+                        {editing[item.id] ? (
+                          <IconButton onClick={() => saveDescription(item.id)}>
+                            <SaveIcon />
+                          </IconButton>
+                        ) : (
+                          <IconButton
+                            onClick={() => startEdit(item.id, item.description)}
+                          >
+                            <EditIcon />
+                          </IconButton>
+                        )}
+                        <IconButton
+                          onClick={() => handleDelete(item.id)}
+                          sx={{ color: 'red' }}
+                        >
+                          <DeleteIcon />
+                        </IconButton>
+                      </Box>
+                    </Box>
+                  </Collapse>
+                </ListItem>
+              ))}
+              <ListItem disablePadding>
+                <IconButton onClick={handleAdd}>+</IconButton>
+                <TextField
+                  variant="standard"
+                  placeholder="Add an item"
+                  value={newItemText}
+                  onChange={(e) => setNewItemText(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter') {
+                      handleAdd();
+                    }
+                  }}
+                  fullWidth
+                  sx={{ ml: 1 }}
+                />
+              </ListItem>
+            </List>
+          </Paper>
+        )}
+      </Container>
     </Box>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -152,16 +152,24 @@ function App() {
         <Box sx={{ p: 2 }}>
           {editing[item.id] ? (
             <TextField
+              autoFocus
               fullWidth
               multiline
               variant="standard"
               value={descriptions[item.id] || ''}
+              onFocus={(e) => e.target.select()}
               onChange={(e) =>
                 setDescriptions({
                   ...descriptions,
                   [item.id]: e.target.value,
                 })
               }
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && !e.shiftKey) {
+                  e.preventDefault();
+                  saveDescription(item.id);
+                }
+              }}
             />
           ) : (
             <Typography>{item.description}</Typography>

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -1,9 +1,27 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App';
+import { ThemeProvider, createTheme, responsiveFontSizes } from '@mui/material/styles';
+import CssBaseline from '@mui/material/CssBaseline';
+
+let theme = createTheme({
+  palette: {
+    primary: {
+      main: '#1976d2',
+    },
+    secondary: {
+      main: '#ff4081',
+    },
+  },
+});
+
+theme = responsiveFontSizes(theme);
 
 ReactDOM.createRoot(document.getElementById('root') as HTMLElement).render(
   <React.StrictMode>
-    <App />
+    <ThemeProvider theme={theme}>
+      <CssBaseline />
+      <App />
+    </ThemeProvider>
   </React.StrictMode>
 );


### PR DESCRIPTION
## Summary
- Add Material UI theme with responsive fonts and baseline styling
- Introduce "ToDone!" title and usage instructions on landing page with colorful gradient background
- Wrap task list in translucent card and widen inputs for improved mobile and tablet experience

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_689122e3058883259763fd0537b58ba4